### PR TITLE
Fix Fedora ignition script.

### DIFF
--- a/Fedora-20/install.sh
+++ b/Fedora-20/install.sh
@@ -10,8 +10,8 @@ echo "Downloading and flashing Fedora 20"
 # Flash the full image
 curl -L -k https://googledrive.com/host/0B0vm64JM4bFZMjFNTGJBT1ozWjg --progress | unxz | dd of=/dev/mmcblk0 bs=1M conv=fsync
 if [ "x$RESIZE" == "xtrue" ]; then
-	set $(partx -g --nr :-1 /dev/mmcblk0)
-        echo -e "d\n3\nn\np\n3\n${2}\n\nw\n" | fdisk /dev/mmcblk0
+	set $(partx -g --nr -1:-1 /dev/mmcblk0)
+        echo -e "d\n${1}\nn\np\n${1}\n${2}\n\nw\n" | fdisk /dev/mmcblk0
 	e2fsck -f /dev/mmcblk0p3
 	resize2fs /dev/mmcblk0p3
 fi

--- a/Fedora-20/install.sh
+++ b/Fedora-20/install.sh
@@ -10,8 +10,8 @@ echo "Downloading and flashing Fedora 20"
 # Flash the full image
 curl -L -k https://googledrive.com/host/0B0vm64JM4bFZMjFNTGJBT1ozWjg --progress | unxz | dd of=/dev/mmcblk0 bs=1M conv=fsync
 if [ "x$RESIZE" == "xtrue" ]; then
-	SS=$(partx --show /dev/mmcblk0 | cut -f3 -d' ' | tail -1)
-        echo -e "d\n3\nn\np\n\n${SS}\n\nw\n" | fdisk /dev/mmcblk0
+	set $(partx -g --nr :-1 /dev/mmcblk0)
+        echo -e "d\n3\nn\np\n3\n${2}\n\nw\n" | fdisk /dev/mmcblk0
 	e2fsck -f /dev/mmcblk0p3
 	resize2fs /dev/mmcblk0p3
 fi

--- a/Fedora-20/install.sh
+++ b/Fedora-20/install.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 set -e
 echo "Downloading and flashing Fedora 20"
-# Below the --progrss will emit percentage that can be used by the gui to show progress bar
+# Below the --progrss will emit percentage that can be used by the gui to show progress bar at 100%
+# while dd writes slowly to mmc.  If you want progress, kill -USR1 ${pid of dd} will send status to stderr...
+#             18335302+0  records  in  18335302+0 records out 9387674624 bytes
+#             (9.4 GB) copied, 34.6279 seconds, 271 MB/s
+# would require a text widjet instead of a progress bar.
 # the bs=1M is critical since it writes much more efficnient to the micro SD
 # Flash the full image
 curl -L -k https://googledrive.com/host/0B0vm64JM4bFZMjFNTGJBT1ozWjg --progress | unxz | dd of=/dev/mmcblk0 bs=1M conv=fsync
 if [ "x$RESIZE" == "xtrue" ]; then
-	partx --show /dev/mmcblk0 2>&1 | while read NR START END; do : ; done
+	partx --show /dev/mmcblk0 2>/dev/null | while read NR START END; do : ; done
         echo -e "d\n${NR}\nn\np\n${NR}\n${START}\n\nw\n" | fdisk /dev/mmcblk0
 	e2fsck -f /dev/mmcblk0p3
 	resize2fs /dev/mmcblk0p3

--- a/Fedora-20/install.sh
+++ b/Fedora-20/install.sh
@@ -6,8 +6,9 @@ echo "Downloading and flashing Fedora 20"
 # Flash the full image
 curl -L -k https://googledrive.com/host/0B0vm64JM4bFZMjFNTGJBT1ozWjg --progress | unxz | dd of=/dev/mmcblk0 bs=1M conv=fsync
 if [ "x$RESIZE" == "xtrue" ]; then
-	echo -e "d\n3\nn\np\n3\n\n\nw\n" | fdisk /dev/mmcblk0
-	e2fsck -f /dev/mmcblk0p3 || true
-	resize2fs /dev/mmcblk0p3 || true
+	partx --show /dev/mmcblk0 2>&1 | while read NR START END; do : ; done
+        echo -e "d\n${NR}\nn\np\n${NR}\n${START}\n\nw\n" | fdisk /dev/mmcblk0
+	e2fsck -f /dev/mmcblk0p3
+	resize2fs /dev/mmcblk0p3
 fi
 sync

--- a/Fedora-20/install.sh
+++ b/Fedora-20/install.sh
@@ -10,8 +10,8 @@ echo "Downloading and flashing Fedora 20"
 # Flash the full image
 curl -L -k https://googledrive.com/host/0B0vm64JM4bFZMjFNTGJBT1ozWjg --progress | unxz | dd of=/dev/mmcblk0 bs=1M conv=fsync
 if [ "x$RESIZE" == "xtrue" ]; then
-	partx --show /dev/mmcblk0 2>/dev/null | while read NR START END; do : ; done
-        echo -e "d\n${NR}\nn\np\n${NR}\n${START}\n\nw\n" | fdisk /dev/mmcblk0
+	SS=$(partx --show /dev/mmcblk0 | cut -f3 -d' ' | tail -1)
+        echo -e "d\n3\nn\np\n\n${SS}\n\nw\n" | fdisk /dev/mmcblk0
 	e2fsck -f /dev/mmcblk0p3
 	resize2fs /dev/mmcblk0p3
 fi


### PR DESCRIPTION
Fedora ignition script writes image to mmc then attempts to resize p3 of the downloaded image to fill the entire mmc device.  It fails because the author makes the assumption that fdisk will suggest the same start address for the replacement as the original partition.  In the case on the live server, it does not.  When this is the case, the subsequent e2fs operations error out.

To correct the deficiency I added one line of code to record the start address of the last partition on the newly imaged mmc and modified one line to use to use the partition # and start sector of that partition.
