### PR TITLE
Fix resize algorithm.

### DIFF
--- a/Fedora-20/install.sh
+++ b/Fedora-20/install.sh
@@ -6,8 +6,9 @@ echo "Downloading and flashing Fedora 20"
 # Flash the full image
 curl -L -k https://googledrive.com/host/0B0vm64JM4bFZMjFNTGJBT1ozWjg --progress | unxz | dd of=/dev/mmcblk0 bs=1M conv=fsync
 if [ "x$RESIZE" == "xtrue" ]; then
-	echo -e "d\n3\nn\np\n3\n\n\nw\n" | fdisk /dev/mmcblk0
-	e2fsck -f /dev/mmcblk0p3 || true
-	resize2fs /dev/mmcblk0p3 || true
+	set $(partx -g --nr -1:-1 /dev/mmcblk0)
+        echo -e "d\n${1}\nn\np\n${1}\n${2}\n\nw\n" | fdisk /dev/mmcblk0
+	e2fsck -f /dev/mmcblk0p3
+	resize2fs /dev/mmcblk0p3
 fi
 sync


### PR DESCRIPTION
e2fsck and resize2fs failing because fdisk does not default the same start sector for new as deleted.
