### PR TITLE
Update XBian install.sh with new sourceforge URL

### DIFF
--- a/XBian/install.sh
+++ b/XBian/install.sh
@@ -4,7 +4,7 @@
 set -o pipefail
 
 # try to download and flash image, and collect exist status
-curl -L -k "https://sourceforge.net/projects/xbian/files/release/XBian_Latest_imx6.img/download" --progress | gunzip | dd of=/dev/mmcblk0 bs=1M conv=fsync
+curl -L -k "https://sourceforge.net/projects/xbian/files/release/XBian_Latest_imx6.img.gz/download" --progress | gunzip | dd of=/dev/mmcblk0 bs=1M conv=fsync
 s=$?
 
 # return exit status of download/flashing


### PR DESCRIPTION
The URL on sourceforge seems to have changed slightly, images have a .gz file extension now which is not in the curl URL of install.sh