### PR TITLE
Update Volumio download to latest version

### DIFF
--- a/Volumio/install.sh
+++ b/Volumio/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 # Remove white spaces
-curl -L -k "http://sourceforge.net/projects/volumio/files/Cubox-i/1.5/Volumio1.5Cuboxi.img.zip/download" --progress > /tmp/volumio.zip
+curl -L -k "http://updates.volumio.org/cuboxi/volumio/2.129/volumio-2.129-2017-03-26-cuboxi.img.zip" --progress > /tmp/volumio.zip
 cd /tmp
-unzip volumio.zip Volumio1.5Cuboxi.img -p | dd of=/dev/mmcblk0 bs=1M conv=fsync
+unzip volumio.zip volumio-2.129-2017-03-26-cubox.img -p | dd of=/dev/mmcblk0 bs=1M conv=fsync
 sync


### PR DESCRIPTION
This updates the install of Volumio to the latest version, 2.129, which is a major new version with significant changes.