### PR TITLE
ArchLinux: fix U-Boot installation

### DIFF
--- a/ArchLinux/install.sh
+++ b/ArchLinux/install.sh
@@ -7,7 +7,7 @@ mount /dev/mmcblk0p1 /mnt
 cd /mnt
 curl -L -k http://archlinuxarm.org/os/ArchLinuxARM-imx6-cubox-latest.tar.gz --progress | tar -zxf -
 dd if=boot/SPL of=/dev/mmcblk0 bs=1K seek=1
-dd if=boot/u-boot.img of=/dev/mmcblk0 bs=1K seek=42
+dd if=boot/u-boot.img of=/dev/mmcblk0 bs=1K seek=69
 cd /
 umount /mnt
 sync


### PR DESCRIPTION
Recent ArchLinux versions use upstream U-Boot where the main U-Boot image is
in offset of 69KB. Update the U-Boot installation command.