### PR TITLE
Fixed stable OpenELEC version

### DIFF
--- a/OpenELEC.tv/DESCRIPTION
+++ b/OpenELEC.tv/DESCRIPTION
@@ -1,1 +1,1 @@
-The official OpenELEC.tv 6 release - http://www.openelec.tv
+The official OpenELEC.tv 8 release - http://www.openelec.tv

--- a/OpenELEC.tv/NAME
+++ b/OpenELEC.tv/NAME
@@ -1,1 +1,1 @@
-OpenELEC.tv 6.0.3 release
+OpenELEC.tv 8.0.4 release

--- a/OpenELEC.tv/install.sh
+++ b/OpenELEC.tv/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 echo "Downloading and installing"
-curl -L -k http://releases.openelec.tv/OpenELEC-imx6.arm-6.0.3.img.gz --progress | gunzip | dd of=/dev/mmcblk0 bs=1M conv=fsync
+curl -L -k http://releases.openelec.tv/OpenELEC-imx6.arm-8.0.4.img.gz --progress | gunzip | dd of=/dev/mmcblk0 bs=1M conv=fsync
 sync


### PR DESCRIPTION
Changed v6 to v8. The source code of v6 is no longer available.
http://openelec.tv/get-openelec