### PR TITLE
Automatically get the LibreELEC image name

### DIFF
--- a/LibreELEC.tv/install.sh
+++ b/LibreELEC.tv/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -e
+
+IMG=$(wget -q https://libreelec.tv/downloads/cubox-i2-i4-hummingboard/ -O - | grep -oh '<a href=.*.img.gz">' | cut -f2 -d'"')
+
 echo "Downloading and installing"
-curl -L -k http://releases.libreelec.tv/LibreELEC-imx6.arm-7.0.1.img.gz --progress | gunzip | dd of=/dev/mmcblk0 bs=1M conv=fsync
+curl -L -k ${IMG} --progress | gunzip | dd of=/dev/mmcblk0 bs=1M conv=fsync
 sync


### PR DESCRIPTION
Get the current image name by parsing the html code of the download page.
It was hardcoded version 7.0.1 (broken link), now at version 8.2.5.